### PR TITLE
fix link to network-policy.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ that do not run ovn-kubernetes.
 [OVN multicast](./docs/multicast.md) enables data to be delivered to multiple IP addresses simultaneously.
 For this to happen, the 'receivers' join a multicast group, and the sender(s) send data to it.
 
-[NetworkPolicy](./docs/network-policy.md) features and examples. By default the network traffic from and
+[NetworkPolicy](./docs/networkpolicies/network-policy.md) features and examples. By default the network traffic from and
 to K8s pods is not restricted in any way. Using NetworkPolicy is a way to enforce network isolation
 of selected pods.
 


### PR DESCRIPTION
Link to network-policy.md residing in the subdir ./doc/networkpolicies to fix current 404. 

(./doc/networkpolicies/admin-network-policy.md might still miss linkage from the current documentation)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->